### PR TITLE
Add missing ClientStorage constructor kw args to resolver.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -99,3 +99,4 @@ Contributors
 - Chris McDonough, 2011/08/18
 - Georges Dubus, 2012/05/27
 - Tres Seaver, 2012/05/27
+- Todd Koym, 2016/07/21

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,6 +159,8 @@ min_disconnect_poll
   integer
 max_disconnect_poll
   integer
+wait_for_server_on_startup (deprecated alias for wait)
+  boolean
 wait
   boolean
 wait_timeout
@@ -166,6 +168,8 @@ wait_timeout
 read_only
   boolean
 read_only_fallback
+  boolean
+drop_cache_rather_verify
   boolean
 username
   string
@@ -177,6 +181,12 @@ blob_dir
   string
 shared_blob_dir
   boolean
+blob_cache_size
+  bytesize
+blob_cache_size_check
+  integer
+client_label
+  string
 
 Misc
 ++++

--- a/zodburi/resolvers.py
+++ b/zodburi/resolvers.py
@@ -108,7 +108,7 @@ class FileStorageURIResolver(Resolver):
             def factory():
                 filestorage = FileStorage(*args, **kw)
                 return BlobStorage(blobstorage_dir, filestorage,
-                                          layout=blobstorage_layout)
+                                   layout=blobstorage_layout)
         elif demostorage:
             def factory():
                 filestorage = FileStorage(*args, **kw)
@@ -124,10 +124,11 @@ class ClientStorageURIResolver(Resolver):
     _int_args = ('debug', 'min_disconnect_poll', 'max_disconnect_poll',
                  'wait_for_server_on_startup', 'wait', 'wait_timeout',
                  'read_only', 'read_only_fallback', 'shared_blob_dir',
-                 'demostorage')
+                 'demostorage', 'drop_cache_rather_verify',
+                 'blob_cache_size_check')
     _string_args = ('storage', 'name', 'client', 'var', 'username',
-                    'password', 'realm', 'blob_dir')
-    _bytesize_args = ('cache_size', )
+                    'password', 'realm', 'blob_dir', 'client_label')
+    _bytesize_args = ('cache_size', 'blob_cache_size')
 
     def __call__(self, uri):
         # urlsplit doesnt understand zeo URLs so force to something that

--- a/zodburi/tests/test_resolvers.py
+++ b/zodburi/tests/test_resolvers.py
@@ -268,11 +268,64 @@ class TestClientStorageURIResolver(unittest.TestCase):
         ClientStorage.assert_called_once_with('/var/nosuchfile', wait=0)
 
     @mock.patch('zodburi.resolvers.ClientStorage')
+    def test_factory_kwargs(self, ClientStorage):
+        resolver = self._makeOne()
+        factory, dbkw = resolver('zeo:///var/nosuchfile?'
+                                 'storage=main&'
+                                 'cache_size=1kb&'
+                                 'name=foo&'
+                                 'client=bar&'
+                                 'var=baz&'
+                                 'min_disconnect_poll=2&'
+                                 'max_disconnect_poll=3&'
+                                 'wait_for_server_on_startup=true&'
+                                 'wait=4&'
+                                 'wait_timeout=5&'
+                                 'read_only=6&'
+                                 'read_only_fallback=7&'
+                                 'drop_cache_rather_verify=true&'
+                                 'username=monty&'
+                                 'password=python&'
+                                 'realm=blat&'
+                                 'blob_dir=some/dir&'
+                                 'shared_blob_dir=true&'
+                                 'blob_cache_size=1kb&'
+                                 'blob_cache_size_check=8&'
+                                 'client_label=fink&'
+                                 )
+        storage = factory()
+        storage.close()
+        ClientStorage.assert_called_once_with('/var/nosuchfile',
+                                              storage='main',
+                                              cache_size=1024,
+                                              name='foo',
+                                              client='bar',
+                                              var='baz',
+                                              min_disconnect_poll=2,
+                                              max_disconnect_poll=3,
+                                              wait_for_server_on_startup=1,
+                                              wait=4,
+                                              wait_timeout=5,
+                                              read_only=6,
+                                              read_only_fallback=7,
+                                              drop_cache_rather_verify=1,
+                                              username='monty',
+                                              password='python',
+                                              realm='blat',
+                                              blob_dir='some/dir',
+                                              shared_blob_dir=1,
+                                              blob_cache_size=1024,
+                                              blob_cache_size_check=8,
+                                              client_label='fink',
+                                              )
+
+
+    @mock.patch('zodburi.resolvers.ClientStorage')
     def test_invoke_factory_demostorage(self, ClientStorage):
         from ZODB.DemoStorage import DemoStorage
         resolver = self._makeOne()
         factory, dbkw = resolver('zeo:///var/nosuchfile?wait=false'
-                                        '&demostorage=true')
+                                 '&demostorage=true')
         storage = factory()
         storage.close()
         self.assertTrue(isinstance(storage, DemoStorage))
@@ -280,9 +333,9 @@ class TestClientStorageURIResolver(unittest.TestCase):
     def test_dbargs(self):
         resolver = self._makeOne()
         factory, dbkw = resolver('zeo://localhost:8080?debug=true&'
-                                        'connection_pool_size=1&'
-                                        'connection_cache_size=1&'
-                                        'database_name=dbname')
+                                 'connection_pool_size=1&'
+                                 'connection_cache_size=1&'
+                                 'database_name=dbname')
         self.assertEqual(dbkw, {'connection_pool_size': '1',
                                 'connection_cache_size': '1',
                                 'database_name': 'dbname'})


### PR DESCRIPTION
I needed to be able to pass a blob_cache_size argument in the URI, but the resolver was tossing it out. I added it and other ClientStorage constructor keyword arguments that weren't being recognized by the resolver.

By the way, this is my first pull request. If I should have done something different, let me know.