### PR TITLE
setup: Fix thinko for test_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setup(name='zodburi',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
-      tests_require = requires,
-      install_requires = tests_require,
+      tests_require = tests_require,
+      install_requires = requires,
       test_suite="zodburi",
       entry_points="""\
       [zodburi.resolvers]


### PR DESCRIPTION
It is test_require who should list all packages needed for testing, but
because of thinko in 3833be7e (Convert db resolvers to storage
resolvers.) it was the other way.

This resulted in zodburi install always pulling in mock. Fix it.