### PR TITLE
Fix PendingDeprecationWarning about cgi.parse_qsl

### DIFF
--- a/zodburi/_compat.py
+++ b/zodburi/_compat.py
@@ -1,7 +1,7 @@
 try:
     from urllib.parse import parse_qsl
 except ImportError: #pragma NO COVER
-    from cgi import parse_qsl
+    from urlparse import parse_qsl
 
 try:
     from urllib.parse import quote


### PR DESCRIPTION
I was running py.test based tests on a project which uses zodburi and
got many warnings:

	.../python2.7/site-packages/zodburi/resolvers.py:86: PendingDeprecationWarning: cgi.parse_qsl is deprecated, use urlparse.parse_qsl instead
	  kw = dict(parse_qsl(query))
	  ...

Since for Python2 `cgi.parse_qsl` was migrated to `urlparse.parse_qsl` in 2008:

https://github.com/python/cpython/commit/c585df9476

it is safe to change to `urlparse.parse_qsl` unconditionally.

Thanks beforehand,
Kirill