### PR TITLE
zodb4 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,27 @@ sudo: false
 matrix:
     include:
         - python: 2.7
-          env: TOXENV=py27
+          env: TOXENV=py27-zodb4
+        - python: 2.7
+          env: TOXENV=py27-zodb5
         - python: 3.4
-          env: TOXENV=py34
+          env: TOXENV=py34-zodb4
+        - python: 3.4
+          env: TOXENV=py34-zodb5
         - python: 3.5
-          env: TOXENV=py35
+          env: TOXENV=py35-zodb4
+        - python: 3.5
+          env: TOXENV=py35-zodb5
         - python: 3.6
-          env: TOXENV=py36
+          env: TOXENV=py36-zodb4
+        - python: 3.6
+          env: TOXENV=py36-zodb5
         - python: 3.7
-          env: TOXENV=py37
+          env: TOXENV=py37-zodb5
           dist: xenial
           sudo: true
         - python: 3.8-dev
-          env: TOXENV=py38
+          env: TOXENV=py38-zodb5
           dist: xenial
           sudo: true
     allow_failures:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -103,3 +103,4 @@ Contributors
 - Todd Koym, 2016/07/21
 - Jim Fulton, 2017/04/13
 - Kirill Smelkov, 2017/10/17
+- Éloi Rivard, 2019/01/18

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,cover,docs
+    {py27,py34,py35,py36}-{zodb4,zodb5},py37-zodb5,cover,docs
 
 [testenv]
 commands =
     python setup.py -q test -q
 deps =
     mock
+    zodb4: ZODB==4.*
+    zodb5: ZODB==5.*
+    zodb4: ZEO==4.*
+    zodb5: ZEO==5.*
 
 [testenv:cover]
 basepython =

--- a/zodburi/tests/test_resolvers.py
+++ b/zodburi/tests/test_resolvers.py
@@ -1,5 +1,10 @@
 import mock
+import pkg_resources
 import unittest
+
+
+ZODB_VERSION = tuple(map(int, pkg_resources.get_distribution("ZODB").version.split('.')))
+
 
 class Base:
 
@@ -437,15 +442,26 @@ class TestZConfigURIResolver(unittest.TestCase):
         storage = factory()
         from ZODB.MappingStorage import MappingStorage
         self.assertTrue(isinstance(storage, MappingStorage))
-        self.assertEqual(dbkw,
-                         {'connection_cache_size': 5000,
-                          'connection_cache_size_bytes': 0,
-                          'connection_historical_cache_size': 1000,
-                          'connection_historical_cache_size_bytes': 0,
-                          'connection_historical_pool_size': 3,
-                          'connection_historical_timeout': 300,
-                          'connection_large_record_size': 16777216,
-                          'connection_pool_size': 7})
+        if ZODB_VERSION[0] < 5:
+            self.assertEqual(dbkw,
+                             {'connection_cache_size': 5000,
+                              'connection_cache_size_bytes': 0,
+                              'connection_historical_cache_size': 1000,
+                              'connection_historical_cache_size_bytes': 0,
+                              'connection_historical_pool_size': 3,
+                              'connection_historical_timeout': 300,
+                              'connection_pool_size': 7})
+        else:
+            self.assertEqual(dbkw,
+                             {'connection_cache_size': 5000,
+                              'connection_cache_size_bytes': 0,
+                              'connection_historical_cache_size': 1000,
+                              'connection_historical_cache_size_bytes': 0,
+                              'connection_historical_pool_size': 3,
+                              'connection_historical_timeout': 300,
+                              'connection_large_record_size': 16777216,
+                              'connection_pool_size': 7})
+
 
     def test_named_database(self):
         self.tmp.write(b"""
@@ -463,16 +479,28 @@ class TestZConfigURIResolver(unittest.TestCase):
         storage = factory()
         from ZODB.MappingStorage import MappingStorage
         self.assertTrue(isinstance(storage, MappingStorage))
-        self.assertEqual(dbkw,
-                         {'connection_cache_size': 20000,
-                          'connection_cache_size_bytes': 0,
-                          'connection_historical_cache_size': 1000,
-                          'connection_historical_cache_size_bytes': 0,
-                          'connection_historical_pool_size': 3,
-                          'connection_historical_timeout': 300,
-                          'connection_large_record_size': 16777216,
-                          'connection_pool_size': 5,
-                          'database_name': 'foo'})
+        if ZODB_VERSION[0] < 5:
+            self.assertEqual(dbkw,
+                             {'connection_cache_size': 20000,
+                              'connection_cache_size_bytes': 0,
+                              'connection_historical_cache_size': 1000,
+                              'connection_historical_cache_size_bytes': 0,
+                              'connection_historical_pool_size': 3,
+                              'connection_historical_timeout': 300,
+                              'connection_pool_size': 5,
+                              'database_name': 'foo'})
+        else:
+            self.assertEqual(dbkw,
+                             {'connection_cache_size': 20000,
+                              'connection_cache_size_bytes': 0,
+                              'connection_historical_cache_size': 1000,
+                              'connection_historical_cache_size_bytes': 0,
+                              'connection_historical_pool_size': 3,
+                              'connection_historical_timeout': 300,
+                              'connection_large_record_size': 16777216,
+                              'connection_pool_size': 5,
+                              'database_name': 'foo'})
+
 
     def test_database_all_options(self):
         from zodburi import connection_parameters, bytes_parameters
@@ -518,16 +546,28 @@ class TestZConfigURIResolver(unittest.TestCase):
         storage = factory()
         from ZODB.MappingStorage import MappingStorage
         self.assertTrue(isinstance(storage, MappingStorage))
-        self.assertEqual(dbkw,
-                         {'cache_size': 5000,
-                          'cache_size_bytes': 0,
-                          'historical_cache_size': 1000,
-                          'historical_cache_size_bytes': 0,
-                          'historical_pool_size': 3,
-                          'historical_timeout': 300,
-                          'large_record_size': 16777216,
-                          'pool_size': 7,
-                          'database_name': 'unnamed'})
+        if ZODB_VERSION[0] < 5:
+            self.assertEqual(dbkw,
+                             {'cache_size': 5000,
+                              'cache_size_bytes': 0,
+                              'historical_cache_size': 1000,
+                              'historical_cache_size_bytes': 0,
+                              'historical_pool_size': 3,
+                              'historical_timeout': 300,
+                              'pool_size': 7,
+                              'database_name': 'unnamed'})
+        else:
+            self.assertEqual(dbkw,
+                             {'cache_size': 5000,
+                              'cache_size_bytes': 0,
+                              'historical_cache_size': 1000,
+                              'historical_cache_size_bytes': 0,
+                              'historical_pool_size': 3,
+                              'historical_timeout': 300,
+                              'large_record_size': 16777216,
+                              'pool_size': 7,
+                              'database_name': 'unnamed'})
+
 
 class TestMappingStorageURIResolver(Base, unittest.TestCase):
 


### PR DESCRIPTION
Hi. It is written in the zodburi documentation that zodb minimum required version is 3. I did not have the courage to bring zodb3 in the tests, but at least there is zodb4 :)

I think it can be useful to ensure future commits will not break backward compatibility.