### PR TITLE
demo: URI resolver

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,8 +43,8 @@ URI Schemes
 -----------
 
 The URI schemes currently recognized in the ``zodbconn.uri`` setting
-are ``file://``, ``zeo://``, ``zconfig://``, ``memory://``
-.  Documentation for these URI scheme syntaxes are below.
+are ``file://``, ``zeo://``, ``zconfig://``, ``memory://`` and ``demo:``.
+Documentation for these URI scheme syntaxes are below.
 
 In addition to those schemes, the relstorage_ package adds support for
 ``postgres://``.
@@ -355,6 +355,29 @@ Example
 An example that combines a dbname with a query string::
 
    memory://storagename?connection_cache_size=100&database_name=fleeb
+
+
+``demo:`` URI scheme
+~~~~~~~~~~~~~~~~~~~~
+
+The ``demo:`` URI scheme can be passed as ``zodbconn.uri`` to create a
+DemoStorage database factory. DemoStorage provides an overlay combining base
+and δ ("delta", or in other words, "changes") storages.
+The URI scheme contains two parts, base and δ::
+
+    demo:(base_uri)/(δ_uri)
+
+an optional fragment specifies arguments for ``ZODB.DB.DB`` constructor::
+
+    demo:(base_uri)/(δ_uri)#dbkw
+
+Example
++++++++
+
+An example that combines ZEO with local FileStorage for changes::
+
+    demo:(zeo://localhost:9001?storage=abc)/(file:///path/to/Changes.fs)
+
 
 More Information
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(name='zodburi',
       file = zodburi.resolvers:file_storage_resolver
       zconfig = zodburi.resolvers:zconfig_resolver
       memory = zodburi.resolvers:mapping_storage_resolver
+      demo = zodburi.resolvers:demo_storage_resolver
       """,
       extras_require = {
         'testing': testing_extras,

--- a/zodburi/__init__.py
+++ b/zodburi/__init__.py
@@ -8,12 +8,17 @@ def resolve_uri(uri):
     returns a storage matching the spec defined in the uri.  dbkw is a dict of
     keyword arguments that may be passed to ZODB.DB.DB.
     """
+    factory, dbkw = _resolve_uri(uri)
+    return factory, _get_dbkw(dbkw)
+
+# _resolve_uri serves resolve_uri: it returns factory and original raw dbkw.
+def _resolve_uri(uri):
     scheme = uri[:uri.find(':')]
     for ep in iter_entry_points('zodburi.resolvers'):
         if ep.name == scheme:
             resolver = ep.load()
             factory, dbkw = resolver(uri)
-            return factory, _get_dbkw(dbkw)
+            return factory, dbkw
     else:
         raise KeyError('No resolver found for uri: %s' % uri)
 


### PR DESCRIPTION
This patch adds `demo:` URI scheme to create DemoStorage from an URI.

While several existing resolvers already handle ?demostorage argument to
wrap itself with DemoStorage and in-RAM MappingStorage for changes, this
approach has the following drawbacks:

- every resolver must do it
- it is not possible to create DemoStorage with non-MappingStorage for changes.

My particular motivation here is Wendelin.core 2: it spawns WCFS
filesystem server to serve array data from ZODB storage, and passes
storage URL to spawned wcfs process, so that wcfs could connect and
retrieve data from the same ZODB storage that client process is
using. When original ERP5 client is using DemoStorage, both `base` and
`changes` must be persisted because if changes would be in-RAM
MappingStorage, WCFS could not access that data because it runs as a
separate process.

To build a DemoStorage URI we follow XRI Cross-references approach to
embed URIs for base and changes into combining demo URI:

    demo:(base_uri)/(δ_uri)

https://en.wikipedia.org/wiki/Extensible_Resource_Identifier provides
some related details and examples.

I choose fragments as the place for ZODB.DB arguments:

    demo:(base_uri)/(δ_uri)#dbkw...

The reason fragments - instead of parameters - are used, is because
DB arguments are _local_. Even with different DB arguments the URI
refers to the same storage, and for wendelin.core 2 it is important to
be able to determine whether two client processes actually use the same
underlying ZODB storage, even if those two clients use different local
parameters, like connection_pool_size and similar. Keeping such local
arguments in fragments makes it easy to determine the underlying URI of
the storage - by dropping fragments. It also follows logic from RFC 3986,
which says that "fragment ... may be ... some view on representations of
the primary resource": https://tools.ietf.org/html/rfc3986#section-3.5

Thanks beforehand,
Kirill

/cc @tseaver, @azmeuk, @jimfulton

P.S.

It was already suggested several times to add DemoStorageURIResolver and
deprecate ?demostorage in existing URI resolvers:

https://github.com/Pylons/zodburi/pull/25#issuecomment-485506959
https://github.com/Pylons/zodburi/pull/25#issuecomment-511480572
https://github.com/Pylons/zodburi/pull/25#issuecomment-622931793