### PR TITLE
Release gardening

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ prune docs/_build
 graft zodburi
 
 include README.rst
+include RELEASING.txt
 include CHANGES.rst
 include contributing.md
 include CONTRIBUTORS.txt

--- a/RELEASING.txt
+++ b/RELEASING.txt
@@ -1,14 +1,24 @@
-========================
- Making zodburi release
-========================
+We use zest.releaser for release automation.
 
-To make a next release, by default, command ``fullrelease`` from
-`zest.releaser`__ works fine. It will go through to update version number,
-changelog, commit and tag those changes, upload the package to PyPI, and to
-further switch the source tree for the next development cycle.
+https://pypi.org/project/zest.releaser/
 
-If/when needed, one could manually make all the steps described above.
-See `Packaging Python Projects`__ and zodburi git history for details.
+To make a new release, first prepare by adding any omitted entries to
+CHANGES.rst. Then use the following command, accepting all default options:
 
-__ https://pypi.org/project/zest.releaser/
-__ https://packaging.python.org/tutorials/packaging-projects/
+    fullrelease
+
+It will go through to update version number, changelog, commit and tag those
+changes, upload the package to PyPI, and to further switch the source tree for
+the next development cycle.
+
+See zest.releaser documentation for details:
+
+https://zestreleaser.readthedocs.io/en/latest/overview.html#available-commands
+
+
+If/when needed, one could also manually make all release steps described above.
+See "Packaging Python Projects"
+
+https://packaging.python.org/tutorials/packaging-projects/
+
+and zodburi git history for details.

--- a/RELEASING.txt
+++ b/RELEASING.txt
@@ -1,0 +1,14 @@
+========================
+ Making zodburi release
+========================
+
+To make a next release, by default, command ``fullrelease`` from
+`zest.releaser`__ works fine. It will go through to update version number,
+changelog, commit and tag those changes, upload the package to PyPI, and to
+further switch the source tree for the next development cycle.
+
+If/when needed, one could manually make all the steps described above.
+See `Packaging Python Projects`__ and zodburi git history for details.
+
+__ https://pypi.org/project/zest.releaser/
+__ https://packaging.python.org/tutorials/packaging-projects/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    lint
     {py27,py35,py36,pypy,pypy3}-{zodb4,zodb5},{py37,py38}-zodb5,cover,docs
 
 [testenv]
@@ -37,3 +38,17 @@ commands =
 deps =
     Sphinx
     pylons-sphinx-themes
+
+
+[testenv:lint]
+skip_install = true
+commands =
+    check-manifest
+    # build sdist/wheel
+    python setup.py sdist
+    python setup.py bdist_wheel
+    twine check dist/*
+deps =
+    check-manifest
+    readme_renderer
+    twine

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    lint
-    {py27,py35,py36,pypy,pypy3}-{zodb4,zodb5},{py37,py38}-zodb5,cover,docs
+    {py27,py35,py36,pypy,pypy3}-{zodb4,zodb5},
+    {py37,py38}-zodb5,
+    cover,docs,lint
 
 [testenv]
 commands =
@@ -44,11 +45,21 @@ deps =
 skip_install = true
 commands =
     check-manifest
-    # build sdist/wheel
-    python setup.py sdist
-    python setup.py bdist_wheel
-    twine check dist/*
 deps =
     check-manifest
-    readme_renderer
+
+[testenv:build]
+skip_install = true
+commands =
+    # clean up build/ and dist/ folders
+    python -c 'import shutil; shutil.rmtree("dist", ignore_errors=True)'
+    python setup.py clean --all
+    # build sdist
+    python setup.py sdist --dist-dir {toxinidir}/dist
+    # build wheel from sdist
+    pip wheel -v --no-deps --no-index --no-build-isolation --wheel-dir {toxinidir}/dist --find-links {toxinidir}/dist zodburi
+    twine check dist/*
+deps =
+    setuptools
     twine
+    wheel


### PR DESCRIPTION
- add `lint` target to tox as suggested by @bertjwregeer to verify that manifest is ok,
- add `RELEASING.txt` to document how to make a new release

/cc @jamadden, @azmeuk, @stevepiercy 