### PR TITLE
Remove support for ZODB4 and python<3.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,30 @@
+---
+name: tests
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - '3.11'
+          - '3.10'
+          - '3.9'
+          - '3.8'
+          - '3.7'
+          - 'pypy-3.7'
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip|${{ hashFiles('setup.py') }}|${{ hashFiles('tox.ini') }}
+      - run: pip install tox
+      - run: tox -e py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Change Log
 
 - Stop support for ZODB4
 
+- Stop support for python<3.7
+
 
 2.5.0 (2021-05-12)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,10 @@
 Change Log
 ----------
 
-2.5.1 (unreleased)
+2.6.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Stop support for ZODB4
 
 
 2.5.0 (2021-05-12)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # zodburi documentation build configuration file
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,14 +7,14 @@ Overview
 A library which parses URIs and converts them to ZODB storage objects and
 database arguments.
 
-It will run under CPython 2.7, 3.5 to 3.8, pypy and pypy3.  It will not run under Jython.  It requires ZODB >= 5.0.0.
+It will run under CPython 3.7+ and pypy3.  It will not run under Jython.  It requires ZODB >= 5.0.0.
 
 Installation
 ------------
 
-Install using setuptools, e.g. (within a virtualenv)::
+Install using pip, e.g. (within a virtualenv)::
 
-  $ easy_install zodburi
+  $ pip install zodburi
 
 Using
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Overview
 A library which parses URIs and converts them to ZODB storage objects and
 database arguments.
 
-It will run under CPython 2.7, 3.5 to 3.8, pypy and pypy3.  It will not run under Jython.  It requires ZODB >= 3.10.0.
+It will run under CPython 2.7, 3.5 to 3.8, pypy and pypy3.  It will not run under Jython.  It requires ZODB >= 5.0.0.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ here = os.path.abspath(os.path.dirname(__file__))
 try:
     with open(os.path.join(here, 'README.rst')) as f:
         README = f.read()
-except IOError:
+except OSError:
     README = ''
 
 try:
     with open(os.path.join(here, 'CHANGES.rst')) as f:
         CHANGES = f.read()
-except IOError:
+except OSError:
     CHANGES = ''
 
 requires = ['ZODB', 'ZConfig', 'ZEO']
@@ -33,13 +33,12 @@ setup(name='zodburi',
       classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "License :: Repoze Public License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,14 @@
 [tox]
 envlist =
-    {py27,py35,py36,pypy,pypy3}-{zodb4,zodb5},
-    {py37,py38}-zodb5,
-    cover,docs,lint
+    py27,py35,py36,py37,py38,pypy,pypy3,cover,docs,lint
 
 [testenv]
 commands =
     python setup.py -q test -q
 deps =
     mock
-    zodb4: ZODB==4.*
-    zodb5: ZODB==5.*
-    zodb4: ZEO==4.*
-    zodb5: ZEO==5.*
+    ZODB==5.*
+    ZEO==5.*
 
 [testenv:cover]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py35,py36,py37,py38,pypy,pypy3,cover,docs,lint
+    py37,py38,py39,py310,py311,pypy3,cover,docs,lint
 
 [testenv]
 commands =
@@ -12,7 +12,7 @@ deps =
 
 [testenv:cover]
 basepython =
-    python3.7
+    python3.9
 commands =
     python setup.py nosetests --with-xunit --with-xcoverage
 deps =
@@ -29,7 +29,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python3.7
+    python3.11
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
 deps =

--- a/zodburi/__init__.py
+++ b/zodburi/__init__.py
@@ -35,7 +35,7 @@ parameters = dict(database_name = 'database_name')
 for parameter in connection_parameters:
     parameters['connection_' + parameter] = parameter
 
-has_units = re.compile('\s*(\d+)\s*([kmg])b\s*$').match
+has_units = re.compile(r'\s*(\d+)\s*([kmg])b\s*$').match
 units = dict(k=1<<10, m=1<<20, g=1<<30)
 def _parse_bytes(s):
     m = has_units(s.lower())

--- a/zodburi/resolvers.py
+++ b/zodburi/resolvers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from io import BytesIO
 import os
 import re
@@ -19,11 +18,8 @@ from zodburi._compat import parse_qsl
 from zodburi._compat import urlsplit
 from zodburi import _resolve_uri
 
-# Capability test for older Pythons (2.x < 2.7.4, 3.x < 3.2.4)
-(scheme, netloc, path, query, frag) = urlsplit('scheme:///path/#frag')
-_BROKEN_URLSPLIT = frag != 'frag'
 
-class Resolver(object):
+class Resolver:
     _int_args = ()
     _string_args = ()
     _bytesize_args = ()
@@ -161,7 +157,7 @@ class ClientStorageURIResolver(Resolver):
         return factory, unused
 
 
-class ZConfigURIResolver(object):
+class ZConfigURIResolver:
 
     schema_xml_template = b"""
     <schema>
@@ -173,11 +169,6 @@ class ZConfigURIResolver(object):
 
     def __call__(self, uri):
         (scheme, netloc, path, query, frag) = urlsplit(uri)
-        if _BROKEN_URLSPLIT: #pragma NO COVER
-            # urlsplit used not to allow fragments in non-standard schemes,
-            # stuffed everything into 'path'
-            (scheme, netloc, path, query, frag
-            ) = urlsplit('http:' + path)
         path = os.path.normpath(path)
         schema_xml = self.schema_xml_template
         schema = loadSchemaFile(BytesIO(schema_xml))
@@ -208,7 +199,7 @@ class ZConfigURIResolver(object):
         return factory.open, dbkw
 
 
-class DemoStorageURIResolver(object):
+class DemoStorageURIResolver:
 
     # demo:(base_uri)/(δ_uri)#dbkw...
     # URI format follows XRI Cross-references to refer to base and δ

--- a/zodburi/tests/__init__.py
+++ b/zodburi/tests/__init__.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import unittest
 
 

--- a/zodburi/tests/test_resolvers.py
+++ b/zodburi/tests/test_resolvers.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pkg_resources
 import unittest
 
@@ -208,8 +208,8 @@ class TestFileStorageURIResolver(Base, unittest.TestCase):
     def test_dbargs(self):
         resolver = self._makeOne()
         factory, dbkw = resolver(
-            ('file:///tmp/../foo/bar?connection_pool_size=1'
-             '&connection_cache_size=1&database_name=dbname'))
+            'file:///tmp/../foo/bar?connection_pool_size=1'
+             '&connection_cache_size=1&database_name=dbname')
         self.assertEqual(dbkw, {'connection_cache_size': '1',
                                 'connection_pool_size': '1',
                                 'database_name': 'dbname'})
@@ -487,7 +487,7 @@ class TestZConfigURIResolver(unittest.TestCase):
           database-name foo
           %s
         </zodb>
-        """ % '\n'.join("%s %s" % (
+        """ % '\n'.join("{} {}".format(
                             name.replace('_', '-'),
                             '%sMB' % i if name in bytes_parameters else i,
                            )
@@ -587,7 +587,7 @@ class TestDemoStorageURIResolver(unittest.TestCase):
         changef = os.path.join(tmpdir, 'changes.fs')
         self.assertFalse(os.path.exists(basef))
         self.assertFalse(os.path.exists(changef))
-        factory, dbkw = resolver('demo:(file://%s)/(file://%s?quota=200)' % (basef, changef))
+        factory, dbkw = resolver('demo:(file://{})/(file://{}?quota=200)'.format(basef, changef))
         self.assertEqual(dbkw, {})
         demo = factory()
         from ZODB.DemoStorage import DemoStorage

--- a/zodburi/tests/test_resolvers.py
+++ b/zodburi/tests/test_resolvers.py
@@ -3,9 +3,6 @@ import pkg_resources
 import unittest
 
 
-ZODB_VERSION = tuple(map(int, pkg_resources.get_distribution("ZODB").version.split('.')))
-
-
 class Base:
 
     def test_interpret_kwargs_noargs(self):
@@ -442,25 +439,15 @@ class TestZConfigURIResolver(unittest.TestCase):
         storage = factory()
         from ZODB.MappingStorage import MappingStorage
         self.assertTrue(isinstance(storage, MappingStorage))
-        if ZODB_VERSION[0] < 5:
-            self.assertEqual(dbkw,
-                             {'connection_cache_size': 5000,
-                              'connection_cache_size_bytes': 0,
-                              'connection_historical_cache_size': 1000,
-                              'connection_historical_cache_size_bytes': 0,
-                              'connection_historical_pool_size': 3,
-                              'connection_historical_timeout': 300,
-                              'connection_pool_size': 7})
-        else:
-            self.assertEqual(dbkw,
-                             {'connection_cache_size': 5000,
-                              'connection_cache_size_bytes': 0,
-                              'connection_historical_cache_size': 1000,
-                              'connection_historical_cache_size_bytes': 0,
-                              'connection_historical_pool_size': 3,
-                              'connection_historical_timeout': 300,
-                              'connection_large_record_size': 16777216,
-                              'connection_pool_size': 7})
+        self.assertEqual(dbkw,
+                         {'connection_cache_size': 5000,
+                          'connection_cache_size_bytes': 0,
+                          'connection_historical_cache_size': 1000,
+                          'connection_historical_cache_size_bytes': 0,
+                          'connection_historical_pool_size': 3,
+                          'connection_historical_timeout': 300,
+                          'connection_large_record_size': 16777216,
+                          'connection_pool_size': 7})
 
 
     def test_named_database(self):
@@ -479,27 +466,16 @@ class TestZConfigURIResolver(unittest.TestCase):
         storage = factory()
         from ZODB.MappingStorage import MappingStorage
         self.assertTrue(isinstance(storage, MappingStorage))
-        if ZODB_VERSION[0] < 5:
-            self.assertEqual(dbkw,
-                             {'connection_cache_size': 20000,
-                              'connection_cache_size_bytes': 0,
-                              'connection_historical_cache_size': 1000,
-                              'connection_historical_cache_size_bytes': 0,
-                              'connection_historical_pool_size': 3,
-                              'connection_historical_timeout': 300,
-                              'connection_pool_size': 5,
-                              'database_name': 'foo'})
-        else:
-            self.assertEqual(dbkw,
-                             {'connection_cache_size': 20000,
-                              'connection_cache_size_bytes': 0,
-                              'connection_historical_cache_size': 1000,
-                              'connection_historical_cache_size_bytes': 0,
-                              'connection_historical_pool_size': 3,
-                              'connection_historical_timeout': 300,
-                              'connection_large_record_size': 16777216,
-                              'connection_pool_size': 5,
-                              'database_name': 'foo'})
+        self.assertEqual(dbkw,
+                         {'connection_cache_size': 20000,
+                          'connection_cache_size_bytes': 0,
+                          'connection_historical_cache_size': 1000,
+                          'connection_historical_cache_size_bytes': 0,
+                          'connection_historical_pool_size': 3,
+                          'connection_historical_timeout': 300,
+                          'connection_large_record_size': 16777216,
+                          'connection_pool_size': 5,
+                          'database_name': 'foo'})
 
 
     def test_database_all_options(self):
@@ -546,27 +522,16 @@ class TestZConfigURIResolver(unittest.TestCase):
         storage = factory()
         from ZODB.MappingStorage import MappingStorage
         self.assertTrue(isinstance(storage, MappingStorage))
-        if ZODB_VERSION[0] < 5:
-            self.assertEqual(dbkw,
-                             {'cache_size': 5000,
-                              'cache_size_bytes': 0,
-                              'historical_cache_size': 1000,
-                              'historical_cache_size_bytes': 0,
-                              'historical_pool_size': 3,
-                              'historical_timeout': 300,
-                              'pool_size': 7,
-                              'database_name': 'unnamed'})
-        else:
-            self.assertEqual(dbkw,
-                             {'cache_size': 5000,
-                              'cache_size_bytes': 0,
-                              'historical_cache_size': 1000,
-                              'historical_cache_size_bytes': 0,
-                              'historical_pool_size': 3,
-                              'historical_timeout': 300,
-                              'large_record_size': 16777216,
-                              'pool_size': 7,
-                              'database_name': 'unnamed'})
+        self.assertEqual(dbkw,
+                         {'cache_size': 5000,
+                          'cache_size_bytes': 0,
+                          'historical_cache_size': 1000,
+                          'historical_cache_size_bytes': 0,
+                          'historical_pool_size': 3,
+                          'historical_timeout': 300,
+                          'large_record_size': 16777216,
+                          'pool_size': 7,
+                          'database_name': 'unnamed'})
 
 
 class TestMappingStorageURIResolver(Base, unittest.TestCase):


### PR DESCRIPTION
This PR:
- removes support for python<3.7 (I applied pyupgrade --py37-plus on all the files)
- removes support for ZODB4
- adds GHA tests