### PR TITLE
Deprecate ?demostorage in favour of demo://

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Change Log
 2.6.1 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Deprecate ``?demostorage`` in favour of ``demo:`` URI scheme.
 
 
 2.6.0 (2023-05-17)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -163,6 +163,12 @@ blobstorage_dir
 blobstorage_layout
   string
 
+Misc
+++++
+
+demostorage (deprecated in favour of ``demo:`` URI scheme)
+  boolean (if true, wrap FileStorage in a DemoStorage)
+
 Example
 +++++++
 
@@ -236,6 +242,12 @@ blob_cache_size_check
   integer
 client_label
   string
+
+Misc
+++++
+
+demostorage (deprecated in favour of ``demo:`` URI scheme)
+  boolean (if true, wrap ClientStorage in a DemoStorage)
 
 Connection-related
 ++++++++++++++++++

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -163,12 +163,6 @@ blobstorage_dir
 blobstorage_layout
   string
 
-Misc
-++++
-
-demostorage
-  boolean (if true, wrap FileStorage in a DemoStorage)
-
 Example
 +++++++
 
@@ -242,12 +236,6 @@ blob_cache_size_check
   integer
 client_label
   string
-
-Misc
-++++
-
-demostorage
-  boolean (if true, wrap ClientStorage in a DemoStorage)
 
 Connection-related
 ++++++++++++++++++

--- a/zodburi/resolvers.py
+++ b/zodburi/resolvers.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 import os
 import re
+import warnings
 
 from ZConfig import loadConfig
 from ZConfig import loadSchemaFile
@@ -89,6 +90,8 @@ class FileStorageURIResolver(Resolver):
         if 'demostorage'in kw:
             kw.pop('demostorage')
             demostorage = True
+            warnings.warn("demostorage option is deprecated, use demo:// instead",
+                          DeprecationWarning)
 
         blobstorage_dir = None
         blobstorage_layout = 'automatic'
@@ -149,6 +152,8 @@ class ClientStorageURIResolver(Resolver):
         kw, unused = self.interpret_kwargs(kw)
         if 'demostorage' in kw:
             kw.pop('demostorage')
+            warnings.warn("demostorage option is deprecated, use demo:// instead",
+                          DeprecationWarning)
             def factory():
                 return DemoStorage(base=ClientStorage(*args, **kw))
         else:

--- a/zodburi/tests/test_resolvers.py
+++ b/zodburi/tests/test_resolvers.py
@@ -1,6 +1,7 @@
 from unittest import mock
 import pkg_resources
 import unittest
+import warnings
 
 
 class Base:
@@ -154,8 +155,13 @@ class TestFileStorageURIResolver(Base, unittest.TestCase):
         from ZODB.DemoStorage import DemoStorage
         from ZODB.FileStorage import FileStorage
         resolver = self._makeOne()
-        factory, dbkw = resolver(
-            'file://%s/db.db?demostorage=true' % self.tmpdir)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            factory, dbkw = resolver(
+                'file://%s/db.db?demostorage=true' % self.tmpdir)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("demostorage option is deprecated, use demo:// instead", str(w[-1].message))
         storage = factory()
         self.assertTrue(isinstance(storage, DemoStorage))
         self.assertTrue(isinstance(storage.base, FileStorage))
@@ -193,10 +199,15 @@ class TestFileStorageURIResolver(Base, unittest.TestCase):
         BLOB_DIR = os.path.join(self.tmpdir, 'blob')
         self.assertFalse(os.path.exists(DB_FILE))
         resolver = self._makeOne()
-        factory, dbkw = resolver(
-            'file://%s/db.db?quota=200&demostorage=true'
-            '&blobstorage_dir=%s/blob'
-            '&blobstorage_layout=bushy' % (self.tmpdir, q(self.tmpdir)))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            factory, dbkw = resolver(
+                'file://%s/db.db?quota=200&demostorage=true'
+                '&blobstorage_dir=%s/blob'
+                '&blobstorage_layout=bushy' % (self.tmpdir, q(self.tmpdir)))
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("demostorage option is deprecated, use demo:// instead", str(w[-1].message))
         storage = factory()
         self.assertTrue(isinstance(storage, DemoStorage))
         try:
@@ -340,8 +351,13 @@ class TestClientStorageURIResolver(unittest.TestCase):
     def test_invoke_factory_demostorage(self, ClientStorage):
         from ZODB.DemoStorage import DemoStorage
         resolver = self._makeOne()
-        factory, dbkw = resolver('zeo:///var/nosuchfile?wait=false'
-                                 '&demostorage=true')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            factory, dbkw = resolver('zeo:///var/nosuchfile?wait=false'
+                                     '&demostorage=true')
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("demostorage option is deprecated, use demo:// instead", str(w[-1].message))
         storage = factory()
         storage.close()
         self.assertTrue(isinstance(storage, DemoStorage))


### PR DESCRIPTION
In 2021 in 2f02bc90 (demo: URI resolver) we added support for generic demo:// URI scheme which allows combining any two storages into a DemoStorage. This support is more generic because e.g. previously ?demostorage was provided only by file:// and zeo:// URI schemes, with the "changes" part there being hardcoded to in-memory MappingStorage.

Now there is no need to use ?demostorage option as we can use demo:// uniformly.

Deprecating ?demostorage in favour of dedicated DemoStorage resolver was actually suggested several times in the past:

https://github.com/Pylons/zodburi/pull/25#issuecomment-485506959  
https://github.com/Pylons/zodburi/pull/25#issuecomment-511480572  
https://github.com/Pylons/zodburi/pull/25#issuecomment-622931793  

/cc @azmeuk, @stevepiercy 