### PR TITLE
zeo: Fix parsing URI with empty host

### DIFF
--- a/zodburi/resolvers.py
+++ b/zodburi/resolvers.py
@@ -144,6 +144,8 @@ class ClientStorageURIResolver(Resolver):
             port = u.port
             if port is None:
                 port = 9991
+            if host is None:  # zeo://:123 used to parse into ('', 123) on py2
+                host = ''
             args = ((host, port),)
         else:
             # Unix domain socket URL

--- a/zodburi/tests/test_resolvers.py
+++ b/zodburi/tests/test_resolvers.py
@@ -317,6 +317,7 @@ def test_fsresolver_invoke_factory_w_blobstorage_and_demostorage(tmpdir):
 @pytest.mark.parametrize("uri, expected_args, expected_kwargs", [
     ("zeo://localhost", (("localhost", 9991),), {}),
     ("zeo://localhost:8080?debug=true", (("localhost", 8080),), {"debug": 1}),
+    ("zeo://:1234?debug=true", (("", 1234),), {"debug": 1}),
     ("zeo://[::1]", (("::1", 9991),), {}),
     ("zeo://[::1]:9990?debug=true", (("::1", 9990),), {"debug": 1}),
     ("zeo:///var/sock?debug=true", ("/var/sock",), {"debug": 1}),


### PR DESCRIPTION
On Python2 parsing zeo://:1234 was resulting in ('', 1234) addr being passed to ClientStorage. However on Python3, due to change in behaviour of urlsplit, it starts to result in (None, 1234) addr being passed to ClientStorage and failure to establish connection to corresponding ZEO server.

-> Fix that by explicitly checking if urlsplit returned hostname=None and converting that back to '' to preserve backward compatibility.

Here are the details of urlsplit change in behaviour:

    kirr@deca:~$ python2
    Python 2.7.18 (default, Jul 14 2021, 08:11:37)
    [GCC 10.2.1 20210110] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from urlparse import urlsplit
    >>> urlsplit('http://:1234')
    SplitResult(scheme='http', netloc=':1234', path='', query='', fragment='')
    >>> u = urlsplit('http://:1234')
    >>> u.netloc
    ':1234'
    >>> u.hostname		<-- NOTE
    ''

    kirr@deca:~$ python3
    Python 3.11.2 (main, Aug 26 2024, 07:20:54) [GCC 12.2.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from urllib.parse import urlsplit
    >>> u = urlsplit('http://:1234')
    >>> u
    SplitResult(scheme='http', netloc=':1234', path='', query='', fragment='')
    >>> u.netloc
    ':1234'
    >>> u.hostname		<-- NOTE
    >>> repr(u.hostname)
    'None'

Even though .hostname was documented to be returned as None if not present on py2 (https://docs.python.org/2.7/library/urlparse.html#urlparse.urlsplit), the code was actually returning '' for ':port' netloc:

https://github.com/python/cpython/blob/v2.7.18-0-g8d21aa21f2c/Lib/urlparse.py##L100-L101

/cc @perrinjerome, @levinzimmermannn, @vnmabus